### PR TITLE
Add driver.id and rider.locale to docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
 </ul>
 </li>
 <li>
+<p><code>ca</code>: Catalan</p>
+</li>
+<li>
 <p><code>pr</code>: Portuguese (international)</p>
 <ul>
 <li><code>pt-BR</code>: Portuguese / Brasil</li>
@@ -222,7 +225,8 @@ the <code>start_at</code> as the current time and the <code>start_type</code> of
     "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"John Doe"</span></span>,
     "<span class="hljs-attribute">phone_prefix</span>": <span class="hljs-value"><span class="hljs-string">"+34"</span></span>,
     "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value"><span class="hljs-string">"555-1234"</span></span>,
-    "<span class="hljs-attribute">email</span>": <span class="hljs-value"><span class="hljs-string">"jdoe@example.com"</span>
+    "<span class="hljs-attribute">email</span>": <span class="hljs-value"><span class="hljs-string">"jdoe@example.com"</span></span>,
+    "<span class="hljs-attribute">locale</span>": <span class="hljs-value"><span class="hljs-string">"en"</span>
   </span>}</span>,
   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Pick up at the red building next to the supermarket"</span>
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
@@ -263,6 +267,10 @@ the <code>start_at</code> as the current time and the <code>start_type</code> of
         "<span class="hljs-attribute">email</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
           "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"Rider's contact email"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">locale</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"Rider's locale. Used to generate the sms messages we send to the rider"</span>
         </span>}
       </span>}</span>,
       "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
@@ -331,7 +339,8 @@ the <code>start_at</code> as the current time and the <code>start_type</code> of
     "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"John Doe"</span></span>,
     "<span class="hljs-attribute">phone_prefix</span>": <span class="hljs-value"><span class="hljs-string">"+34"</span></span>,
     "<span class="hljs-attribute">phone_number</span>": <span class="hljs-value"><span class="hljs-string">"555-1234"</span></span>,
-    "<span class="hljs-attribute">email</span>": <span class="hljs-value"><span class="hljs-string">"jdoe@example.com"</span>
+    "<span class="hljs-attribute">email</span>": <span class="hljs-value"><span class="hljs-string">"jdoe@example.com"</span></span>,
+    "<span class="hljs-attribute">locale</span>": <span class="hljs-value"><span class="hljs-string">"en"</span>
   </span>}</span>,
   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"Pick up at the red building next to the supermarket"</span></span>,
   "<span class="hljs-attribute">state</span>": <span class="hljs-value">{
@@ -342,6 +351,7 @@ the <code>start_at</code> as the current time and the <code>start_type</code> of
       -<span class="hljs-number">1.1185173</span>
     ]</span>,
     "<span class="hljs-attribute">driver</span>": <span class="hljs-value">{
+      "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"0987654321abcdef0987654321abcdef"</span></span>,
       "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"Martín"</span></span>,
       "<span class="hljs-attribute">surname</span>": <span class="hljs-value"><span class="hljs-string">"de la Cuadra"</span></span>,
       "<span class="hljs-attribute">mobile</span>": <span class="hljs-value"><span class="hljs-string">"555-1234"</span></span>,
@@ -428,6 +438,10 @@ the <code>start_at</code> as the current time and the <code>start_type</code> of
         "<span class="hljs-attribute">email</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
           "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"Rider's contact email"</span>
+        </span>}</span>,
+        "<span class="hljs-attribute">locale</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"Rider's locale. Used to generate the sms messages we send to the rider"</span>
         </span>}
       </span>}</span>,
       "<span class="hljs-attribute">required</span>": <span class="hljs-value">[
@@ -472,13 +486,17 @@ the <code>start_at</code> as the current time and the <code>start_type</code> of
         "<span class="hljs-attribute">driver</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
           "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+            "<span class="hljs-attribute">id</span>": <span class="hljs-value">{
+              "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"id of the Driver."</span>
+            </span>}</span>,
             "<span class="hljs-attribute">name</span>": <span class="hljs-value">{
               "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
               "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"driver's given name."</span>
             </span>}</span>,
             "<span class="hljs-attribute">surname</span>": <span class="hljs-value">{
               "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"driver's family name"</span>
+              "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"driver's family name."</span>
             </span>}</span>,
             "<span class="hljs-attribute">mobile</span>": <span class="hljs-value">{
               "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
@@ -779,6 +797,7 @@ the <code>start_at</code> as the current time and the <code>start_type</code> of
     -<span class="hljs-number">1.1185173</span>
   ]</span>,
   "<span class="hljs-attribute">driver</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"0987654321abcdef0987654321abcdef"</span></span>,
     "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"Martín"</span></span>,
     "<span class="hljs-attribute">surname</span>": <span class="hljs-value"><span class="hljs-string">"de la Cuadra"</span></span>,
     "<span class="hljs-attribute">mobile</span>": <span class="hljs-value"><span class="hljs-string">"555-1234"</span></span>,
@@ -831,13 +850,17 @@ the <code>start_at</code> as the current time and the <code>start_type</code> of
     "<span class="hljs-attribute">driver</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"id of the Driver."</span>
+        </span>}</span>,
         "<span class="hljs-attribute">name</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
           "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"driver's given name."</span>
         </span>}</span>,
         "<span class="hljs-attribute">surname</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"driver's family name"</span>
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"driver's family name."</span>
         </span>}</span>,
         "<span class="hljs-attribute">mobile</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
@@ -964,6 +987,7 @@ the <code>start_at</code> as the current time and the <code>start_type</code> of
     -<span class="hljs-number">1.1185173</span>
   ]</span>,
   "<span class="hljs-attribute">driver</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-string">"0987654321abcdef0987654321abcdef"</span></span>,
     "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"Martín"</span></span>,
     "<span class="hljs-attribute">surname</span>": <span class="hljs-value"><span class="hljs-string">"de la Cuadra"</span></span>,
     "<span class="hljs-attribute">mobile</span>": <span class="hljs-value"><span class="hljs-string">"555-1234"</span></span>,
@@ -1016,13 +1040,17 @@ the <code>start_at</code> as the current time and the <code>start_type</code> of
     "<span class="hljs-attribute">driver</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value">{
+          "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"id of the Driver."</span>
+        </span>}</span>,
         "<span class="hljs-attribute">name</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
           "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"driver's given name."</span>
         </span>}</span>,
         "<span class="hljs-attribute">surname</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
-          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"driver's family name"</span>
+          "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"driver's family name."</span>
         </span>}</span>,
         "<span class="hljs-attribute">mobile</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
@@ -1151,7 +1179,7 @@ The URL’s should start with <code>cabify://cabify</code>. Keep in mind that ev
 <h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname"></span>/profile</span></div></div></div><div id="mobile-deeplink-help" class="resource"><h3 class="resource-heading">Help <a href="#mobile-deeplink-help" class="permalink">&nbsp;&para;</a></h3><div id="mobile-deeplink-help-get" class="action get"><h4 class="action-heading"><div class="name">Help</div><a href="#mobile-deeplink-help-get" class="method get">GET</a><code class="uri">/contact</code></h4><p>Open the help center screen</p>
 <h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname"></span>/contact</span></div></div></div><div id="mobile-deeplink-pricing" class="resource"><h3 class="resource-heading">Pricing <a href="#mobile-deeplink-pricing" class="permalink">&nbsp;&para;</a></h3><div id="mobile-deeplink-pricing-get" class="action get"><h4 class="action-heading"><div class="name">Pricing</div><a href="#mobile-deeplink-pricing-get" class="method get">GET</a><code class="uri">/pricing</code></h4><p>Open pricing screen</p>
 <h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname"></span>/pricing</span></div></div></div><div id="mobile-deeplink-invite-friends" class="resource"><h3 class="resource-heading">Invite friends <a href="#mobile-deeplink-invite-friends" class="permalink">&nbsp;&para;</a></h3><div id="mobile-deeplink-invite-friends-get" class="action get"><h4 class="action-heading"><div class="name">Invite friends</div><a href="#mobile-deeplink-invite-friends-get" class="method get">GET</a><code class="uri">/invite_your_friends</code></h4><p>Open invite your friends screen</p>
-<h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname"></span>/invite_your_friends</span></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 12 Jan 2017</p><script>/* eslint-env browser */
+<h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname"></span>/invite_your_friends</span></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 02 Feb 2017</p><script>/* eslint-env browser */
 /* eslint quotes: [2, "single"] */
 'use strict';
 


### PR DESCRIPTION
Changes:
- Add Catalan as supported language.
- Add attribute `locale` to rider from: https://github.com/cabify/product_ruby_core/pull/1228.
- And `id` to driver from: https://github.com/cabify/product_ruby_core/pull/1220