### PR TITLE
Change syntax highlighter to rouge

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 markdown: kramdown
 markdown_ext: md
 safe: true
-highlighter: pygments
+highlighter: rouge
 # baseurl: "http://maximobility.github.io/cabify_developer"
 baseurl: ""
 sass:


### PR DESCRIPTION
Fixing warning in the github pages build given that they don't support other syntax highlighter than `rouge`.

- Github docs: [Fixing highlighting errors](https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors).